### PR TITLE
Add a semicolon when needed

### DIFF
--- a/tasks/sprite.js
+++ b/tasks/sprite.js
@@ -97,6 +97,9 @@ module.exports = function (grunt) {
 
 				if(coordData){
 					var newCss = css.replace(rurl, '('+ spriteImg +')');
+					if(!newCss.match(/;\s*$/)) {
+						newCss += ';'; //Add a semicolon if needed
+					}
 					newCss += ' background-position:-'+ coordData.x +'px -'+ coordData.y +'px;';
 					cssData = cssData.replace(css, newCss);
 				}


### PR DESCRIPTION
A little bug: when there is no semicolon after the background CSS rule (for example, when the file is optimized with `lessscc`) the result file is broken.
