### PR TITLE
Require 'gm' only when needed

### DIFF
--- a/tasks/sprite.js
+++ b/tasks/sprite.js
@@ -1,8 +1,6 @@
 var 
 spritesmith = require('spritesmith'),
-path = require('path'),
-fs = require('fs'),
-gm = require('gm');
+path = require('path');
 
 module.exports = function (grunt) {
 	"use strict";
@@ -252,6 +250,8 @@ module.exports = function (grunt) {
 				
 				if(sliceData.retinaSliceList && sliceData.retinaSliceList.length){
 					createSprite(sliceData.retinaSliceList, function(err, ret){
+						var gm = require('gm');
+
 						if(err){
 							grunt.fatal(err);
 							return callback(err);


### PR DESCRIPTION
For now `gm` module dependency is mandatory. As far as i know, installing `graphicsmagic` under Windows is not a trivial task. It requires external header files, or something like that. However, it should be an option to use `pngsmith` for building sprites on those Windows machines, where it is impossible (or undesirable) to compile `graphicsmagic` library. On the other hand `gm` is not needed every time - it's just mandatory when sprites for retina display are being processed.

So I decided to require `gm` on-demand. It gives a possibility to not use native C++ modules at all when retina images are not used.
